### PR TITLE
Multiple background jobs - hardcoded setup

### DIFF
--- a/BackgroundJob.cls
+++ b/BackgroundJob.cls
@@ -1,0 +1,70 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "BackgroundJob"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+Option Explicit
+
+Public STR_MODULE As String
+
+Public str_id As String
+
+Public str_full_path As String
+Public str_macro As String
+
+Public bool_is_readonly As Boolean
+Public bool_is_visible As Boolean
+
+Public Function run()
+    Dim wb As Workbook
+        
+    On Error GoTo ERR_LOG_OPEN
+    hndl_log.open_data
+    On Error GoTo 0
+    
+    On Error GoTo ERR_JOB_FAILED
+    ' open job
+    Set wb = util_file.open_wb(str_full_path, bool_is_readonly, bool_is_visible, app.str_password)
+    ' run job
+    Application.run "'" & wb.Name & "'!" & str_macro
+    ' close job
+    Windows(wb.Name).Visible = True
+    wb.Close SaveChanges:=False
+    ' log
+    hndl_log.log db_log.TYPE_INFO, STR_MODULE, "run", "Last run>" & Now
+    On Error GoTo 0
+        
+        
+    On Error GoTo ERR_LOG_CLOSE
+    hndl_log.close_data
+    On Error GoTo 0
+    
+    Exit Function
+ERR_JOB_FAILED:
+    hndl_log.log db_log.TYPE_ERR, STR_MODULE, "run", "Background job has failed. " & Err.Number & ">" & Err.description
+    hndl_log.close_data
+    Exit Function
+ERR_LOG_OPEN:
+    MsgBox "Log error during opening", vbCritical, "Logging error"
+    Exit Function
+ERR_LOG_CLOSE:
+    MsgBox "Log error during closing", vbCritical, "Logging error"
+    Exit Function
+End Function
+
+
+Function before_run()
+    Application.DisplayAlerts = False
+End Function
+
+Function after_run()
+    Application.DisplayAlerts = True
+End Function
+
+Private Sub Class_Initialize()
+    STR_MODULE = "background_job"
+End Sub

--- a/app.bas
+++ b/app.bas
@@ -5,14 +5,36 @@ Public bool_run_on_open As Boolean
 Public str_name As String
 Public str_password As String
 
+Public col_background_jobs As Collection
+
 Public Function init()
     bool_run_on_open = False
+    Set col_background_jobs = New Collection
     
     ' log setup
     hndl_log.init
-    'hndl_log.STR_PATH = "C:\Users\czDanKle\Desktop\KLD\under-construction\wh-map\app\background_job\log\"
-    'hndl_log.STR_FILE_NAME = "log.xlsx"
         
+    ' settings
     hndl_local_setting.init
     ctrl_settings.init
+End Function
+
+Public Function run_jobs()
+    Dim obj_background_job As BackgroundJob
+    
+    For Each obj_background_job In col_background_jobs
+        On Error GoTo WARN_BACKGROUND_JOB_FAILED
+        obj_background_job.before_run
+        obj_background_job.run
+        obj_background_job.after_run
+        On Error GoTo 0
+    Next
+    Exit Function
+WARN_BACKGROUND_JOB_FAILED:
+    hndl_log.log db_log.TYPE_WARN, STR_MODULE, "run_jobs", "Background job: " & obj_background_job.str_id & " has failed."
+    Resume Next
+End Function
+
+Public Function add_job(obj_background_job As BackgroundJob)
+    col_background_jobs.Add obj_background_job, obj_background_job.str_id
 End Function

--- a/ctrl_settings.bas
+++ b/ctrl_settings.bas
@@ -8,6 +8,7 @@ Public obj_settings As Settings
 
 Public Function init()
     Dim str_setting_file As String
+    Dim obj_background_job As BackgroundJob
 
     ' load settings
     Set obj_settings = New Settings
@@ -40,8 +41,19 @@ Public Function init()
     'hndl_log.BOOL_EXTERNAL_DATA_FILE_VISIBILITY = CBool(obj_settings.Item("local:app\\hndl_log.bool_external_data_file_visibility").Value)
     
     ' background job
-    background_job.str_full_path = obj_settings.Item("local:file\\background_job.str_full_path").Value
-    background_job.str_macro = obj_settings.Item("local:app\\background_job.str_macro").Value
+      ' first
+    Set obj_background_job = New BackgroundJob
+    obj_background_job.str_id = "1"
+    obj_background_job.str_full_path = obj_settings.Item("local:file\\background_job.1.str_full_path").Value
+    obj_background_job.str_macro = obj_settings.Item("local:app\\background_job.1.str_macro").Value
+    app.add_job obj_background_job
+    ' second
+    Set obj_background_job = New BackgroundJob
+    obj_background_job.str_id = "2"
+    obj_background_job.str_full_path = obj_settings.Item("local:file\\background_job.2.str_full_path").Value
+    obj_background_job.str_macro = obj_settings.Item("local:app\\background_job.2.str_macro").Value
+    app.add_job obj_background_job
+    
     On Error GoTo 0
     
     On Error GoTo ERR_CLOSE_SETTINGS


### PR DESCRIPTION
It's possible to run more than one background jobs/excel files at one run.
Module background_job was refactored to class.
Module app was customized to be able to run more than one background job
Module ctrl_settings contains hardcoded settings for background jobs
Each background job has to have it's unique name for log file